### PR TITLE
CFR-27: Adds the ability to reference a secret for the Cloud Agent Key

### DIFF
--- a/templates/kubecost-metrics-deployment-template.yaml
+++ b/templates/kubecost-metrics-deployment-template.yaml
@@ -226,7 +226,14 @@ spec:
                   key: prometheus-server-endpoint
             {{- if .Values.cloudAgent }}
             - name: CLOUD_AGENT_KEY
+            {{- if .Values.cloudAgentKeySecretName }}
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.cloudAgentKeySecretName }}
+                  key: CLOUD_AGENT_KEY
+            {{- else }}
               value: {{ .Values.cloudAgentKey }}
+            {{- end }}
             - name: CLOUD_REPORTING_SERVER
               value: {{ .Values.cloudReportingServer }}
             {{- end }}


### PR DESCRIPTION
These changes would allow the Kubecost Cloud Agent to reference a Kubernetes Secret for the value of the agent key.
This is being introduced as an optional value. The standard install config with the key referenced as a helm value is still supported.

Create secret with `kubectl`:

``` shell
kubectl create secret generic kubecost-cloud-cloud-agent-key --from-literal=CLOUD_AGENT_KEY='ey...fQ==' --namespace kubecost-cloud
```

Updated helm install command for the agent to reference the secret:

``` shell
helm upgrade --install kubecost-cloud \
--repo https://kubecost.github.io/kubecost-cloud-agent/ kubecost-cloud-agent \
--namespace kubecost-cloud --create-namespace \
-f https://raw.githubusercontent.com/kubecost/kubecost-cloud-agent/main/values-cloud-agent.yaml \
--set imageVersion="lunar-sandwich.v0.1.2" \
--set cloudAgentKeySecretName="kubecost-cloud-cloud-agent-key" \
--set cloudAgentClusterId="cluster-1" \
--set cloudReportingServer="collector.app.kubecost.com:31357" \
--set networkCosts.enabled=true
```

Secret:
<img width="989" alt="image" src="https://github.com/kubecost/kubecost-cloud-agent/assets/15660532/edd65b59-598c-4da9-95a0-a54ca1f8e123">

Mounted as an ENV in the pod:
<img width="1143" alt="image" src="https://github.com/kubecost/kubecost-cloud-agent/assets/15660532/08e6ec5e-ffa3-4424-923b-c0c57af6f981">

Successful container creation and run
<img width="1495" alt="image" src="https://github.com/kubecost/kubecost-cloud-agent/assets/15660532/55e58ce7-b12e-427c-b6f0-7ef597f70962">

`cluster-1` reporting installed in KC Cloud:
<img width="975" alt="image" src="https://github.com/kubecost/kubecost-cloud-agent/assets/15660532/7ecfeebc-764c-44c6-8500-af1c2fa0e738">

