### PR TITLE
Use .Values.kubecostModel.extraEnv

### DIFF
--- a/templates/kubecost-metrics-deployment-template.yaml
+++ b/templates/kubecost-metrics-deployment-template.yaml
@@ -324,6 +324,12 @@ spec:
                 configMapKeyRef:
                   name: {{ template "cost-analyzer.fullname" . }}
                   key: kubecost-token
+            {{- if .Values.kubecostModel.extraEnv }}
+            {{- range .Values.kubecostModel.extraEnv }}
+            - name: {{ .name }}
+              value: {{ .value }}
+            {{- end }}
+            {{- end }}
     {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
       {{ toYaml .Values.imagePullSecrets | indent 2 }}


### PR DESCRIPTION
Fixes #20 

The documentation found here https://docs.kubecost.com/troubleshooting/troubleshoot-install#configuring-log-levels is not correct so this should fix that!
